### PR TITLE
add stress level metric

### DIFF
--- a/dashboards/jitsi-meet-system.json
+++ b/dashboards/jitsi-meet-system.json
@@ -59,7 +59,7 @@
   "gnetId": 12282,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1612608833620,
+  "iteration": 1613598823724,
   "links": [],
   "panels": [
     {
@@ -2348,6 +2348,111 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Stress Level reported to Jicofo by the videobridge.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {},
+              "custom": {},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "hiddenSeries": false,
+          "id": 51,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.2",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "jitsi_stress_level{instance=~\"$instance.*\"}",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "stress level",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Videobridge Stress Level",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "title": "Additional Metrics",
@@ -2405,5 +2510,5 @@
   "timezone": "",
   "title": "Jitsi Meet & System",
   "uid": "IJXK9Q6Wz",
-  "version": 4
+  "version": 5
 }

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ type videoBridgeStats struct {
 	P2PConferences                        int     `json:"p2p_conferences"`
 	Participants                          int     `json:"participants"`
 	Videostreams                          int     `json:"videostreams"`
+	StressLevel                           float64 `json:"stress_level"`
 	TotalLossControlledParticipantSeconds int     `json:"total_loss_controlled_participant_seconds"`
 	TotalLossLimitedParticipantSeconds    int     `json:"total_loss_limited_participant_seconds"`
 	TotalLossDegradedParticipantSeconds   int     `json:"total_loss_degraded_participant_seconds"`
@@ -94,6 +95,9 @@ jitsi_participants {{.Participants}}
 # HELP jitsi_videostreams An estimation of the number of current video streams forwarded by the bridge.
 # TYPE jitsi_videostreams gauge
 jitsi_videostreams {{.Videostreams}}
+# HELP jitsi_stress_level Stress Level reported to Jicofo by the videobridge.
+# TYPE jitsi_stress_level gauge
+jitsi_stress_level {{.StressLevel}}
 # HELP jitsi_total_loss_controlled_participant_seconds The total number of participant-seconds that are loss-controlled.
 # TYPE jitsi_total_loss_controlled_participant_seconds counter
 jitsi_total_loss_controlled_participant_seconds {{.TotalLossControlledParticipantSeconds}}

--- a/main_test.go
+++ b/main_test.go
@@ -71,6 +71,9 @@ jitsi_participants 4
 # HELP jitsi_videostreams An estimation of the number of current video streams forwarded by the bridge.
 # TYPE jitsi_videostreams gauge
 jitsi_videostreams 0
+# HELP jitsi_stress_level Stress Level reported to Jicofo by the videobridge.
+# TYPE jitsi_stress_level gauge
+jitsi_stress_level 0
 # HELP jitsi_total_loss_controlled_participant_seconds The total number of participant-seconds that are loss-controlled.
 # TYPE jitsi_total_loss_controlled_participant_seconds counter
 jitsi_total_loss_controlled_participant_seconds 0
@@ -129,6 +132,7 @@ jitsi_total_colibri_web_socket_messages_sent 0
   "relay_id": "10.0.0.5:4096",
   "rtp_loss": 0,
   "rtt_aggregate": 0,
+  "stress_level": 0.6,
   "threads": 59,
   "total_bytes_received": 257628359,
   "total_bytes_received_octo": 0,
@@ -206,6 +210,9 @@ jitsi_participants 0
 # HELP jitsi_videostreams An estimation of the number of current video streams forwarded by the bridge.
 # TYPE jitsi_videostreams gauge
 jitsi_videostreams 0
+# HELP jitsi_stress_level Stress Level reported to Jicofo by the videobridge.
+# TYPE jitsi_stress_level gauge
+jitsi_stress_level 0.6
 # HELP jitsi_total_loss_controlled_participant_seconds The total number of participant-seconds that are loss-controlled.
 # TYPE jitsi_total_loss_controlled_participant_seconds counter
 jitsi_total_loss_controlled_participant_seconds 847


### PR DESCRIPTION
I use this exporter in a scaled, multiple videobridge setup. To debug load balancing problems, it's very handy to have the stress level metric at hand.